### PR TITLE
SLURM variables

### DIFF
--- a/code/parallelize/run_ddp_training.sbatch
+++ b/code/parallelize/run_ddp_training.sbatch
@@ -2,7 +2,7 @@
 #SBATCH --nodes=1
 #SBATCH --gres=gpu:4  
 #SBATCH --ntasks-per-node=1
-#SBATCH --cpus-per-task=48
+#SBATCH --cpus-per-task=32
 #SBATCH --account=atmlaml
 #SBATCH --partition=dc-gpu
 #SBATCH --time=00:30:00

--- a/code/parallelize/run_ddp_training.sbatch
+++ b/code/parallelize/run_ddp_training.sbatch
@@ -2,7 +2,7 @@
 #SBATCH --nodes=1
 #SBATCH --gres=gpu:4  
 #SBATCH --ntasks-per-node=1
-#SBATCH --cpus-per-task=32
+#SBATCH --cpus-per-task=128
 #SBATCH --account=atmlaml
 #SBATCH --partition=dc-gpu
 #SBATCH --time=00:30:00

--- a/code/parallelize/run_fsdp_training.sbatch
+++ b/code/parallelize/run_fsdp_training.sbatch
@@ -2,7 +2,7 @@
 #SBATCH --nodes=2
 #SBATCH --gres=gpu:4  
 #SBATCH --ntasks-per-node=1
-#SBATCH --cpus-per-task=32
+#SBATCH --cpus-per-task=128
 #SBATCH --account=atmlaml
 #SBATCH --partition=dc-gpu
 #SBATCH --time=03:00:00

--- a/code/parallelize/run_fsdp_training.sbatch
+++ b/code/parallelize/run_fsdp_training.sbatch
@@ -2,7 +2,7 @@
 #SBATCH --nodes=2
 #SBATCH --gres=gpu:4  
 #SBATCH --ntasks-per-node=1
-#SBATCH --cpus-per-task=128
+#SBATCH --cpus-per-task=32
 #SBATCH --account=atmlaml
 #SBATCH --partition=dc-gpu
 #SBATCH --time=03:00:00

--- a/code/parallelize/run_to_distributed_training.sbatch
+++ b/code/parallelize/run_to_distributed_training.sbatch
@@ -2,7 +2,7 @@
 #SBATCH --nodes=1 ## TODO 17: Increase the number of nodes (e.g., 2) to run the training on multiple nodes.
 #SBATCH --gres=gpu:1 ## TODO 14: Set the number of GPUs to use for training.
 #SBATCH --ntasks-per-node=1
-#SBATCH --cpus-per-task=128
+#SBATCH --cpus-per-task=32
 #SBATCH --account=atmlaml
 #SBATCH --partition=dc-gpu
 #SBATCH --time=03:00:00

--- a/code/parallelize/run_to_distributed_training.sbatch
+++ b/code/parallelize/run_to_distributed_training.sbatch
@@ -2,7 +2,7 @@
 #SBATCH --nodes=1 ## TODO 17: Increase the number of nodes (e.g., 2) to run the training on multiple nodes.
 #SBATCH --gres=gpu:1 ## TODO 14: Set the number of GPUs to use for training.
 #SBATCH --ntasks-per-node=1
-#SBATCH --cpus-per-task=32
+#SBATCH --cpus-per-task=128
 #SBATCH --account=atmlaml
 #SBATCH --partition=dc-gpu
 #SBATCH --time=03:00:00


### PR DESCRIPTION
To use all available physical cores for maximum performance, `--cpus-per-task` is set to `128` for jobs using more than one GPU.
For single-GPU jobs, I set it to `32` to allow a fair comparison.
You can check the linked issue for my explanation.
Fixes #30 